### PR TITLE
Added suport for sub-branch folding via lodash's modular get method

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ Simple utility function to fold and merge DNA structure based on given value.
 ## selectedModes(dna, value)
 
 * `dna` is a tree-like `organic-dna` structure
-* `value` is string
-  * it can contain `+` sign which will indicate multiple folding operations to be executed
+* `value` is a string
+  * it can contain a `+` character which will trigger multiple folding operations
+  * it can contain a `.` character which will trigger a folding operation on a sub-branch
+  * both `+` and `.` can be combined infinitely
 
 ## example
 
@@ -15,3 +17,4 @@ Simple utility function to fold and merge DNA structure based on given value.
     // based on CELL_MODE environment variable one can fold DNA 
     // once via CELL_MODE=existingBranch
     // many times via CELL_MODE=existingBranch1+existingBranch2
+    // many times with sub-branches via CELL_MODE=existingBranch1+existingBranch2+existingBranch2.subbranch

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 var fold = require("organic-dna-fold")
-var get = require("lodash.get")
+var has = require("lodash.has")
 var selectBranch = require("organic-dna-branches").selectBranch
 
 module.exports = function(dna, value){
   var modes = value.split("+")
   modes.forEach(function(m){
-    if(dna[m] || get(dna, m))
+    if(dna[m] || has(dna, m))
       fold(dna, selectBranch(dna, m))
     else
       console.warn("mode ",m," not found in root dna")

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
-var selectBranch = require("organic-dna-branches").selectBranch
 var fold = require("organic-dna-fold")
+var get = require("lodash.get")
+var selectBranch = require("organic-dna-branches").selectBranch
 
 module.exports = function(dna, value){
   var modes = value.split("+")
   modes.forEach(function(m){
-    if(dna[m])
+    if(dna[m] || get(dna, m))
       fold(dna, selectBranch(dna, m))
     else
       console.warn("mode ",m," not found in root dna")

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "main": "index.js",
   "dependencies": {
-    "lodash.get": "^4.3.0",
+    "lodash.has": "^4.3.0",
     "organic-dna-branches": "^0.0.2",
     "organic-dna-fold": "^0.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.2",
   "main": "index.js",
   "dependencies": {
+    "lodash.get": "^4.3.0",
     "organic-dna-branches": "^0.0.2",
     "organic-dna-fold": "^0.1.0"
   },


### PR DESCRIPTION
This PR upgrades the existing ability to fold multiple branches into one, by giving the ability to fold a sub-branch of an existing branch.

This is really useful when defining the DNA for a set of replicated servers. I.e.:

```
_production
  _repl0
  _repl1

CELL_MODE=_production+_production._repl0
CELL_MODE=_production+_production._repl1
```

:warning: : This implementation relies on `lodash`'s modularized `has` method
